### PR TITLE
Add filter options to CacheManager

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -91,10 +91,8 @@ class Api
                 $this->cacheManager = new CacheManager($options[self::OPT_CACHE]['adapter']);
             }
 
-            // set default ttl
-            if (!empty($options[self::OPT_CACHE]['ttl'])){
-                $this->cacheManager->setTtl((int) $options[self::OPT_CACHE]['ttl']);
-            }
+            // set user options
+            $this->cacheManager->setOptions($options[self::OPT_CACHE]);
         }
 
         if (isset($options[self::OPT_ADAPTER]) && !empty($options[self::OPT_ADAPTER])){

--- a/ApiRequest.php
+++ b/ApiRequest.php
@@ -9,6 +9,7 @@
 namespace CSApi;
 
 
+use CSApi\Cache\CacheManager;
 use CSApi\Interfaces\IAuthorization;
 use Exception;
 
@@ -240,8 +241,8 @@ class ApiRequest
                 )
                 ->getResponse();
 
-            if (!is_null($cm)){
-                $cm->getAdapter()->set($this->getRequestHash(), $responseData, $cm->getTtl());
+            if (!is_null($cm) && $cm->mustCacheResponse($this, $responseData)){
+                $cm->getAdapter()->set($this->getRequestHash(), $responseData, $cm->getOptions()[CacheManager::CMO_TTL]);
                 $this->getApi()->log("Stored data in cache");
             }
         }


### PR DESCRIPTION
Set filtered cache responses 
HTTP_METHODS: Array [GET] default 
HTTP_CODES: String (Regex) "2\d\d" default