### PR TITLE
Improvement cache with headers

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -89,6 +89,8 @@ class Api
                 throw new Exception("Cache handler must implements CacheInterface interface");
             }else{
                 $this->cacheManager = new CacheManager($options[self::OPT_CACHE]['adapter']);
+                //remove adapter to not added plus in options
+                unset($options[self::OPT_CACHE]['adapter']);
             }
 
             // set user options

--- a/ApiRequest.php
+++ b/ApiRequest.php
@@ -198,7 +198,7 @@ class ApiRequest
      * @return string
      * @throws Exception
      */
-    private function getRequestUri(){
+    public function getRequestUri(){
         $base_domain = $this->getApi()->getApiBaseUri();
         $path = $this->getPath();
         return "{$base_domain}/{$path}";
@@ -225,7 +225,7 @@ class ApiRequest
     {
         $makeCurl = true;
         if (!is_null($cm = $this->getApi()->getCacheManager())){
-            $responseData = $cm->getAdapter()->get($this->getRequestHash());
+            $responseData = $cm->get($this);
             $makeCurl = is_null($responseData);
             $this->getApi()->log($makeCurl ? "Not found in cache": "Loaded from cache");
         }
@@ -242,7 +242,7 @@ class ApiRequest
                 ->getResponse();
 
             if (!is_null($cm) && $cm->mustCacheResponse($this, $responseData)){
-                $cm->getAdapter()->set($this->getRequestHash(), $responseData, $cm->getOptions()[CacheManager::CMO_TTL]);
+                $cm->set($this, $responseData);
                 $this->getApi()->log("Stored data in cache");
             }
         }

--- a/Cache/CacheManager.php
+++ b/Cache/CacheManager.php
@@ -17,6 +17,7 @@ class CacheManager
     const CMO_TTL = 'ttl';
     const CMO_HTTP_METHODS = 'http_methods';
     const CMO_HTTP_CODES = 'http_codes';
+    const CMO_CACHE_HEADER_RULES = 'cache_header_rules';
 
     /**
      * @var CacheInterface
@@ -26,10 +27,11 @@ class CacheManager
     private $default_options = [
         self::CMO_TTL => 300,
         self::CMO_HTTP_METHODS => [ApiRequest::METHOD_GET],
-        self::CMO_HTTP_CODES => '2\d\d'
+        self::CMO_HTTP_CODES => '2\d\d',
+        self::CMO_CACHE_HEADER_RULES => []
     ];
 
-    /** @var array  */
+    /** @var array */
     private $options = [];
 
     /**
@@ -66,7 +68,7 @@ class CacheManager
     {
         $ret = $this->default_options;
         foreach ($ret as $k => $v) {
-            if (isset($options[$k])){
+            if (isset($options[$k])) {
                 $ret[$k] = $options[$k];
             }
         }
@@ -84,21 +86,55 @@ class CacheManager
         return $this;
     }
 
+
+    private function createHash(ApiRequest $request)
+    {
+        $str_params = $request->getParams();
+        if (is_array($str_params)) {
+            ksort($str_params);
+        }
+        $str_params = json_encode($str_params);
+        $headers = '';
+        if ($this->options[self::CMO_CACHE_HEADER_RULES]) {
+            $aux = [];
+            foreach ($this->options[self::CMO_CACHE_HEADER_RULES] as $header) {
+                $aux[] = json_encode($request->getHeaders()[$headers]);
+            }
+            $headers = implode("|", $aux);
+        }
+
+        return md5($request->getMethod() .
+            $request->getRequestUri() .
+            $headers .
+            $str_params);
+    }
+
+    public function get(ApiRequest $request, $default_value = null)
+    {
+        return $this->getAdapter()->get($this->createHash($request), $default_value);
+    }
+
+    public function set(ApiRequest $request, $data)
+    {
+        return $this->getAdapter()->set($this->createHash($request), $data, $this->getOptions()[CacheManager::CMO_TTL]);
+    }
+
     /**
      * @param ApiRequest $request
      * @param string $responseData
      * @return bool
      * @throws \Exception
      */
-    public function mustCacheResponse(ApiRequest $request, string $responseData){
+    public function mustCacheResponse(ApiRequest $request, string $responseData)
+    {
         // check method allowed to cache
-        if (!in_array(strtoupper($request->getMethod()), $this->getOptions()[self::CMO_HTTP_METHODS])){
+        if (!in_array(strtoupper($request->getMethod()), $this->getOptions()[self::CMO_HTTP_METHODS])) {
             return false;
         }
 
         // check http_code allowed to cache
         $data = json_decode($responseData, true);
-        if (!preg_match('/^'.$this->getOptions()[self::CMO_HTTP_CODES].'$/', $data['statusCode'])){
+        if (!preg_match('/^' . $this->getOptions()[self::CMO_HTTP_CODES] . '$/', $data['statusCode'])) {
             return false;
         }
 

--- a/Cache/CacheManager.php
+++ b/Cache/CacheManager.php
@@ -17,7 +17,7 @@ class CacheManager
     const CMO_TTL = 'ttl';
     const CMO_HTTP_METHODS = 'http_methods';
     const CMO_HTTP_CODES = 'http_codes';
-    const CMO_CACHE_HEADER_RULES = 'cache_header_rules';
+    const CMO_USE_HEADERS_CACHE = 'cache_header';
 
     /**
      * @var CacheInterface
@@ -28,7 +28,7 @@ class CacheManager
         self::CMO_TTL => 300,
         self::CMO_HTTP_METHODS => [ApiRequest::METHOD_GET],
         self::CMO_HTTP_CODES => '2\d\d',
-        self::CMO_CACHE_HEADER_RULES => []
+        self::CMO_USE_HEADERS_CACHE => false
     ];
 
     /** @var array */
@@ -95,15 +95,10 @@ class CacheManager
         }
         $str_params = json_encode($str_params);
         $headers = '';
-        if ($this->options[self::CMO_CACHE_HEADER_RULES]) {
-            $aux = [];
-            foreach ($this->options[self::CMO_CACHE_HEADER_RULES] as $header) {
-                $aux[] = json_encode($request->getHeaders()[$headers]);
-            }
-            $headers = implode("|", $aux);
+        if ($this->options[self::CMO_USE_HEADERS_CACHE]) {
+            $headers = implode("|",$request->getHeaders());
         }
-
-        return md5($request->getMethod() .
+        return  md5($request->getMethod() .
             $request->getRequestUri() .
             $headers .
             $str_params);

--- a/Tests/test.php
+++ b/Tests/test.php
@@ -26,7 +26,8 @@ $cacheAdapter = new \CSApi\Cache\Adapter\MemcachePool($mCli);
         'debug' => true,
         'cache' => [
             'adapter' => $cacheAdapter,
-            'ttl' => 20
+            'ttl' => 20,
+            \CSApi\Cache\CacheManager::CMO_CACHE_HEADER_RULES=>['api-context']
         ]
     ]
 );

--- a/Tests/test.php
+++ b/Tests/test.php
@@ -13,19 +13,22 @@ include "vendor/autoload.php";
 
 error_reporting(E_ERROR);
 
-//$cacheAdapter = new \CSApi\Cache\Adapter\FilesystemPool('./_cache');
-$mCli = class_exists('Memcached') ? new \Memcached() : new \Memcache();
-$mCli->addServer('localhost', 11211);
-
-$cacheAdapter = new \CSApi\Cache\Adapter\MemcachePool($mCli);
+$cacheAdapter = new \CSApi\Cache\Adapter\FilesystemPool('/tmp');
+//$mCli = class_exists('Memcached') ? new \Memcached() : new \Memcache();
+//$mCli->addServer('localhost', 11211);
+//
+//$cacheAdapter = new \CSApi\Cache\Adapter\MemcachePool($mCli);
 
 $api = new Api(
     'https://currency.bunkerdb.com/api/',
     [
+        Api::OPT_LOGGER => function ($message, $level) {
+            echo "LOG: ".$message."\n";
+        },
         Api::OPT_CACHE => [
             'adapter' => $cacheAdapter,
             'ttl' => 30,
-            \CSApi\Cache\CacheManager::CMO_USE_HEADERS_CACHE=>true
+            \CSApi\Cache\CacheManager::CMO_HTTP_HEADERS=>['bapi-context']
         ],
         Api::OPT_ADAPTER => new Curl([
             CURLOPT_TIMEOUT => 600


### PR DESCRIPTION
Se implemento una opción para que se tomen los headers como parte de la llave de la cache.

Se tomo una opcion global CMO_USE_HEADERS_CACHE se pasa en la sontruccion del Api y va en los parametros del cache manager.

Eso lo que hace es tomar todos los headers como parte de la llave de la cache.

No se implemento para especificamente cietros headers, ya que la estructura de pasar los headers al ApiRequest es un string limpio, no son arrays con valores. Lo cual dificultaba su parseo.

Tambien se arreglo parte del codigo que resuelve la obtencion de la llamada del cache

Tambien se modifico el test para usar un ejemplo real. Si se quiere descartar podemos revertir ese commit